### PR TITLE
Strip newline characters from _base64Authorization

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -865,6 +865,7 @@ bool HTTPClient::sendHeader(const char * type)
     }
 
     if(_base64Authorization.length()) {
+        _base64Authorization.replace("\n", "");
         header += F("Authorization: Basic ");
         header += _base64Authorization;
         header += "\r\n";


### PR DESCRIPTION
The libb64 base64 library adds newline characters to the base64 encoding of the _base64Authorization String every 72 characters.  This causes problems with the Authorization: Basic http header when the username and password are long.  This change strips out any newlines from _base64Authorization right before the header is sent.